### PR TITLE
Feature/auth

### DIFF
--- a/src/main/java/com/example/goormtodoback/config/SecurityConfig.java
+++ b/src/main/java/com/example/goormtodoback/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.goormtodoback.config;
 
+import com.example.goormtodoback.jwt.JwtFilter;
+import com.example.goormtodoback.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 // Security 설정
 // 요청이 들어왔을 때 보안 검사를 진행
@@ -20,6 +23,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     private final CorsConfig corsConfig;
+    private final JwtUtil jwtUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -47,8 +51,11 @@ public class SecurityConfig {
                         ).permitAll()
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
+                )
+                .addFilterBefore(
+                        new JwtFilter(jwtUtil),
+                        UsernamePasswordAuthenticationFilter.class
                 );
-
         return http.build();
     }
 

--- a/src/main/java/com/example/goormtodoback/controller/AuthController.java
+++ b/src/main/java/com/example/goormtodoback/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.example.goormtodoback.controller;
+
+import com.example.goormtodoback.common.response.ApiResponse;
+import com.example.goormtodoback.domain.dto.auth.LoginRequest;
+import com.example.goormtodoback.domain.dto.auth.LoginResponse;
+import com.example.goormtodoback.domain.dto.auth.RegisterRequest;
+import com.example.goormtodoback.domain.dto.auth.RegisterResponse;
+import com.example.goormtodoback.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    // 회원가입
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<RegisterResponse>> register(
+            @RequestBody RegisterRequest request) {
+        RegisterResponse data = authService.register(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("회원가입이 완료되었습니다.", data));
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+            @RequestBody LoginRequest request) {
+        LoginResponse data = authService.login(request);
+        return ResponseEntity.ok(ApiResponse.success("로그인에 성공했습니다.", data));
+    }
+}

--- a/src/main/java/com/example/goormtodoback/domain/dto/auth/LoginRequest.java
+++ b/src/main/java/com/example/goormtodoback/domain/dto/auth/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.example.goormtodoback.domain.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/example/goormtodoback/domain/dto/auth/LoginResponse.java
+++ b/src/main/java/com/example/goormtodoback/domain/dto/auth/LoginResponse.java
@@ -1,0 +1,10 @@
+package com.example.goormtodoback.domain.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/example/goormtodoback/domain/dto/auth/RegisterRequest.java
+++ b/src/main/java/com/example/goormtodoback/domain/dto/auth/RegisterRequest.java
@@ -1,0 +1,15 @@
+package com.example.goormtodoback.domain.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterRequest {
+    private String username;
+    private String nickname;
+    private String password;
+    private String email;
+}

--- a/src/main/java/com/example/goormtodoback/domain/dto/auth/RegisterResponse.java
+++ b/src/main/java/com/example/goormtodoback/domain/dto/auth/RegisterResponse.java
@@ -1,0 +1,16 @@
+package com.example.goormtodoback.domain.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RegisterResponse {
+    private Long id;
+    private String username;
+    private String nickname;
+    private String email;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/goormtodoback/domain/entity/User.java
+++ b/src/main/java/com/example/goormtodoback/domain/entity/User.java
@@ -1,0 +1,41 @@
+package com.example.goormtodoback.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Column(nullable = false, unique = true, length = 225)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 225)
+    private String passwordHash;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public User(String username, String nickname, String email, String passwordHash) {
+        this.username = username;
+        this.nickname = nickname;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/goormtodoback/jwt/JwtFilter.java
+++ b/src/main/java/com/example/goormtodoback/jwt/JwtFilter.java
@@ -1,0 +1,39 @@
+package com.example.goormtodoback.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+
+            if (jwtUtil.validateToken(token)) {
+                String username = jwtUtil.getUsernameFromToken(token);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(username, null, new ArrayList<>());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/goormtodoback/jwt/JwtUtil.java
+++ b/src/main/java/com/example/goormtodoback/jwt/JwtUtil.java
@@ -1,0 +1,56 @@
+package com.example.goormtodoback.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private final long expiration;
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration}") long expiration
+    ) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+        this.expiration = expiration;
+    }
+
+    // 토큰 생성
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration)) // setExpiration → expiration
+                .signWith(key)
+                .compact();
+    }
+
+    // 토큰에서 username 꺼내기
+    public String getUsernameFromToken(String token) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(key.getEncoded()))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    // 토큰이 유효한지 확인
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(Keys.hmacShaKeyFor(key.getEncoded())) // setSigningKey → verifyWith
+                    .build()
+                    .parseSignedClaims(token);      // parseClaimsJws → parseSignedClaims
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/goormtodoback/repository/UserRepository.java
+++ b/src/main/java/com/example/goormtodoback/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.goormtodoback.repository;
+
+import com.example.goormtodoback.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/goormtodoback/service/AuthService.java
+++ b/src/main/java/com/example/goormtodoback/service/AuthService.java
@@ -1,0 +1,67 @@
+package com.example.goormtodoback.service;
+
+import com.example.goormtodoback.common.exception.CustomException;
+import com.example.goormtodoback.common.exception.ErrorCode;
+import com.example.goormtodoback.domain.entity.User;
+import com.example.goormtodoback.domain.dto.auth.LoginRequest;
+import com.example.goormtodoback.domain.dto.auth.LoginResponse;
+import com.example.goormtodoback.domain.dto.auth.RegisterRequest;
+import com.example.goormtodoback.domain.dto.auth.RegisterResponse;
+import com.example.goormtodoback.jwt.JwtUtil;
+import com.example.goormtodoback.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public RegisterResponse register(RegisterRequest request) {
+
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new CustomException(ErrorCode.USERNAME_DUPLICATED);
+        }
+
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.EMAIL_DUPLICATED);
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        User user = User.builder()
+                .username(request.getUsername())
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .passwordHash(encodedPassword)
+                .build();
+
+        userRepository.save(user);
+
+        return new RegisterResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getCreatedAt()
+        );
+    }
+
+    public LoginResponse login(LoginRequest request) {
+
+        User user = userRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_PASSWORD));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        String token = jwtUtil.generateToken(user.getUsername());
+
+        return new LoginResponse(token);
+    }
+}

--- a/src/test/java/com/example/goormtodoback/service/AuthServiceTest.java
+++ b/src/test/java/com/example/goormtodoback/service/AuthServiceTest.java
@@ -1,0 +1,127 @@
+package com.example.goormtodoback.service;
+
+import com.example.goormtodoback.common.exception.CustomException;
+import com.example.goormtodoback.domain.entity.User;
+import com.example.goormtodoback.domain.dto.auth.LoginRequest;
+import com.example.goormtodoback.domain.dto.auth.LoginResponse;
+import com.example.goormtodoback.domain.dto.auth.RegisterRequest;
+import com.example.goormtodoback.domain.dto.auth.RegisterResponse;
+import com.example.goormtodoback.jwt.JwtUtil;
+import com.example.goormtodoback.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    private User createUser() {
+        return User.builder()
+                .username("goorm")
+                .nickname("구름")
+                .email("goorm@gmail.com")
+                .passwordHash("encodedPassword")
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 - 성공")
+    void register_success() {
+        RegisterRequest request = new RegisterRequest("goorm", "구름", "password123", "goorm@gmail.com");
+
+        given(userRepository.existsByUsername("goorm")).willReturn(false);
+        given(userRepository.existsByEmail("goorm@gmail.com")).willReturn(false);
+        given(passwordEncoder.encode("password123")).willReturn("encodedPassword");
+        given(userRepository.save(any(User.class))).willReturn(createUser());
+
+        RegisterResponse response = authService.register(request);
+
+        assertThat(response.getUsername()).isEqualTo("goorm");
+        assertThat(response.getNickname()).isEqualTo("구름");
+        assertThat(response.getEmail()).isEqualTo("goorm@gmail.com");
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - username 중복")
+    void register_fail_duplicateUsername() {
+        given(userRepository.existsByUsername(any())).willReturn(true);
+
+        assertThatThrownBy(() -> authService.register(new RegisterRequest()))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("이미 사용 중인 아이디입니다.");
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - email 중복")
+    void register_fail_duplicateEmail() {
+        given(userRepository.existsByUsername(any())).willReturn(false);
+        given(userRepository.existsByEmail(any())).willReturn(true);
+
+        assertThatThrownBy(() -> authService.register(new RegisterRequest()))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("이미 사용 중인 이메일입니다.");
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_success() {
+        User user = createUser();
+
+        given(userRepository.findByUsername(any())).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(any(), any())).willReturn(true);
+        given(jwtUtil.generateToken(anyString())).willReturn("fake-token");
+
+        LoginResponse response = authService.login(new LoginRequest());
+
+        assertThat(response.getAccessToken()).isEqualTo("fake-token");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 없는 username")
+    void login_fail_userNotFound() {
+        given(userRepository.findByUsername(any())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest()))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("비밀번호가 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void login_fail_wrongPassword() {
+        User user = createUser();
+
+        given(userRepository.findByUsername(any())).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(any(), any())).willReturn(false);
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest()))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("비밀번호가 일치하지 않습니다.");
+    }
+}


### PR DESCRIPTION
## 요약
- 사용자 인증을 위한 회원가입, 로그인 API를 구현했습니다.
- JWT 기반 인증 필터를 추가하여 토큰 검증 및 보안 설정을 완료했습니다.

## 관련 이슈
- Closes #3 

## 변경 유형
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링/개선
- [x] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점
- `User` Entity 및 `users` 테이블 연동
- `POST /api/v1/auth/register` 회원가입 API 구현
  - username, email 중복 검증
  - BCrypt 비밀번호 암호화 저장
- `POST /api/v1/auth/login` 로그인 API 구현
  - 로그인 성공 시 JWT access token 발급
- `JwtUtil`, `JwtFilter` 구현으로 토큰 기반 인증 처리
- `SecurityConfig`에 JwtFilter 등록 및 인증 경로 설정

## 테스트
- [x] 유닛/통합 테스트 추가 또는 갱신
- [x] 로컬에서 수동 테스트(브라우저/모바일)
- [x] 엣지 케이스 확인(빈 값/긴 텍스트/이모지 등)

**AuthServiceTest 결과 (6개 통과)**
- 회원가입 성공
- 회원가입 실패 - username 중복
- 회원가입 실패 - email 중복
- 로그인 성공
- 로그인 실패 - 없는 username
- 로그인 실패 - 비밀번호 불일치