### PR TITLE
[FEAT] 할일 category, memo 필드 추가

### DIFF
--- a/src/main/java/com/example/goormtodoback/domain/dto/todo/TodoRequest.java
+++ b/src/main/java/com/example/goormtodoback/domain/dto/todo/TodoRequest.java
@@ -16,4 +16,6 @@ public class TodoRequest {
     private LocalDate specificDate;
     private LocalDate startDate;
     private LocalDate endDate;
+    private String category;
+    private String memo;
 }

--- a/src/main/java/com/example/goormtodoback/domain/dto/todo/TodoResponse.java
+++ b/src/main/java/com/example/goormtodoback/domain/dto/todo/TodoResponse.java
@@ -14,6 +14,8 @@ public class TodoResponse {
     private LocalDate specificDate;
     private LocalDate startDate;
     private LocalDate endDate;
+    private String category;
+    private String memo;
     private LocalDateTime createdAt;
 
     public TodoResponse(Todo todo) {
@@ -24,6 +26,8 @@ public class TodoResponse {
         this.specificDate = todo.getSpecificDate();
         this.startDate = todo.getStartDate();
         this.endDate = todo.getEndDate();
+        this.category = todo.getCategory();
+        this.memo = todo.getMemo();
         this.createdAt = todo.getCreatedAt();
     }
 
@@ -35,5 +39,7 @@ public class TodoResponse {
     public LocalDate getSpecificDate() { return specificDate; }
     public LocalDate getStartDate() { return startDate; }
     public LocalDate getEndDate() { return endDate; }
+    public String getCategory() { return category; }
+    public String getMemo() { return memo; }
     public LocalDateTime getCreatedAt() { return createdAt; }
 }

--- a/src/main/java/com/example/goormtodoback/domain/entity/Todo.java
+++ b/src/main/java/com/example/goormtodoback/domain/entity/Todo.java
@@ -39,12 +39,18 @@ public class Todo {
     @Column(name = "end_date")
     private LocalDate endDate;
 
+    @Column(name = "category", length = 10)
+    private String category;  // "FOCUS", "PLAN", "QUICK", "DROP"
+
+    @Column(name = "memo", columnDefinition = "TEXT")
+    private String memo;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
     public Todo(User user, String title, String dateType,
-                LocalDate specificDate, LocalDate startDate, LocalDate endDate) {
+                LocalDate specificDate, LocalDate startDate, LocalDate endDate, String category, String memo) {
         this.user = user;
         this.title = title;
         this.isCompleted = false;
@@ -52,11 +58,13 @@ public class Todo {
         this.specificDate = specificDate;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.category = category;
+        this.memo = memo;
         this.createdAt = LocalDateTime.now();
     }
 
     public void update(String title, Boolean isCompleted, String dateType,
-                       LocalDate specificDate, LocalDate startDate, LocalDate endDate) {
+                       LocalDate specificDate, LocalDate startDate, LocalDate endDate, String category, String memo) {
         if (title != null) this.title = title;
         if (isCompleted != null) this.isCompleted = isCompleted;
         if (dateType != null) {
@@ -65,5 +73,7 @@ public class Todo {
             this.startDate = startDate;
             this.endDate = endDate;
         }
+        if (category != null) this.category = category;
+        if (memo != null) this.memo = memo;
     }
 }

--- a/src/main/java/com/example/goormtodoback/service/TodoService.java
+++ b/src/main/java/com/example/goormtodoback/service/TodoService.java
@@ -76,6 +76,8 @@ public class TodoService {
                 .specificDate(request.getSpecificDate())
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
+                .category(request.getCategory())
+                .memo(request.getMemo())
                 .build();
 
         todoRepository.save(todo);
@@ -97,7 +99,9 @@ public class TodoService {
                 request.getDateType(),
                 request.getSpecificDate(),
                 request.getStartDate(),
-                request.getEndDate()
+                request.getEndDate(),
+                request.getCategory(),
+                request.getMemo()
         );
 
         return new TodoResponse(todo);

--- a/src/test/java/com/example/goormtodoback/service/TodoServiceTest.java
+++ b/src/test/java/com/example/goormtodoback/service/TodoServiceTest.java
@@ -104,7 +104,9 @@ class TodoServiceTest {
         User user = createUser();
         Todo todo = createTodo(user);
 
-        TodoRequest request = new TodoRequest("운동하기", null, "specific", LocalDate.of(2025, 3, 20), null, null);
+        // category, memo 추가
+        TodoRequest request = new TodoRequest("운동하기", null, "specific",
+                LocalDate.of(2025, 3, 20), null, null, "FOCUS", "오늘 꼭 하기");
 
         given(userRepository.findByUsername("goorm")).willReturn(Optional.of(user));
         given(todoRepository.save(any(Todo.class))).willReturn(todo);
@@ -123,7 +125,8 @@ class TodoServiceTest {
 
         given(userRepository.findByUsername("goorm")).willReturn(Optional.of(user));
 
-        TodoRequest request = new TodoRequest("운동하기", null, "invalid", null, null, null);
+        TodoRequest request = new TodoRequest("운동하기", null, "invalid",
+                null, null, null, null, null);
 
         assertThatThrownBy(() -> todoService.createTodo("goorm", request))
                 .isInstanceOf(CustomException.class)
@@ -136,15 +139,16 @@ class TodoServiceTest {
         User user = createUser();
         Todo todo = createTodo(user);
 
-        TodoRequest request = new TodoRequest("운동하기 (수정)", true, null, null, null, null);
+        TodoRequest request = new TodoRequest("운동하기 (수정)", true, null, null, null, null, null, null);
 
         given(userRepository.findByUsername("goorm")).willReturn(Optional.of(user));
         given(todoRepository.findByIdAndUser(1L, user)).willReturn(Optional.of(todo));
 
-        TodoResponse result = todoService.updateTodo("goorm", 1L, request);
+        todoService.updateTodo("goorm", 1L, request);
 
-        assertThat(result.getTitle()).isEqualTo("운동하기 (수정)");
-        assertThat(result.getIsCompleted()).isTrue();
+        // update 메서드가 실제로 호출됐는지 확인
+        assertThat(todo.getTitle()).isEqualTo("운동하기 (수정)");
+        assertThat(todo.isCompleted()).isTrue();
     }
 
     @Test
@@ -155,7 +159,7 @@ class TodoServiceTest {
         given(userRepository.findByUsername("goorm")).willReturn(Optional.of(user));
         given(todoRepository.findByIdAndUser(999L, user)).willReturn(Optional.empty());
 
-        TodoRequest request = new TodoRequest("수정", null, null, null, null, null);
+        TodoRequest request = new TodoRequest("수정", null, null, null, null, null, null, null);
 
         assertThatThrownBy(() -> todoService.updateTodo("goorm", 999L, request))
                 .isInstanceOf(CustomException.class)


### PR DESCRIPTION
## 요약

- 할일에 카테고리(category)와 메모(memo) 필드를 추가했습니다.

- 카테고리는 FOCUS / PLAN / QUICK / DROP 4가지 고정값입니다.



## 관련 이슈
- #4 

## 변경 유형

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링/개선
- [x] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

**Entity**
- `Todo` - `category`, `memo` 필드 추가
- `Todo.update()` - `category`, `memo` 수정 반영

**DTO**
- `TodoRequest` - `category`, `memo` 필드 추가
- `TodoResponse` - `category`, `memo` 필드 추가

**DB**
- `todos` 테이블에 `category VARCHAR(10)`, `memo TEXT` 컬럼 추가

## 테스트

- [x] 유닛/통합 테스트 추가 또는 갱신
- [x] 로컬에서 수동 테스트(브라우저/모바일)
- [ ] 엣지 케이스 확인(빈 값/긴 텍스트/이모지 등)

**TodoServiceTest 결과 (9개 통과)**
- 할일 목록 조회 성공
- 할일 단건 조회 성공
- 할일 단건 조회 실패 - 없는 할일
- 할일 생성 성공 (category, memo 포함)
- 할일 생성 실패 - 잘못된 dateType
- 할일 수정 성공
- 할일 수정 실패 - 없는 할일
- 할일 삭제 성공
- 할일 삭제 실패 - 없는 할일